### PR TITLE
Fix bug in file_exists filter

### DIFF
--- a/_plugins/file-exists.rb
+++ b/_plugins/file-exists.rb
@@ -13,8 +13,9 @@ module Jekyll
       site_source = context.registers[:site].config['source']
       file_path = site_source + '/' + url
 
-      # Check if file exists (returns true or false)
-      "#{File.exist?(file_path.strip!)}"
+      # Trim whitespace just in case and check if the file exists
+      file_path = file_path.strip
+      "#{File.exist?(file_path)}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- ensure file path check doesn't return nil

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d0fb46cc8329a60fc77967b21c09